### PR TITLE
clarify removal of github integration and alternatives

### DIFF
--- a/best-practices/version-control.md
+++ b/best-practices/version-control.md
@@ -1,0 +1,14 @@
+# Version Control
+
+We suggest using Git for version control. You can install Git by adding `git` to the list of packages to install in your Docker image by selecting "Customize Docker image" and adding it at the bottom of the page.
+
+Some considerations:
+
+* Static sites should not have the `public/` directory be the root of the `git` repository. The directory `public/.git` should not exist.
+  As an alternative to making the `public/` directory the root directory, you can make the index folder (in the terminal, this is `/site/`) a Git repository.
+  Generally, dynamic sites' `public/` directories can be the root of the `git` repository, except for sites such as PHP sites.
+
+* If you require SSH (for Git over SSH), then you will also need the `openssh-client` package for an SSH client. Generate a private key using `ssh-keygen -t ed25519`, add it to your preferred
+Git service, and you should be able to use Git for version control.
+
+* In lieu of a webhook performing Git pulls, you will have to run `git pull` manually. There are currently no plans to integrate a webhook.

--- a/faq.md
+++ b/faq.md
@@ -21,3 +21,11 @@ If you really need to work on your site offline, you may want to put your code i
 `Database Shell` gives you a shell where you can type SQL queries and see the result. However, it does this by connecting directly to the server, rather than running the `mysql` or `psql` commands (which was what previous versions of Director did). As a result, you can only enter normal SQL queries -- commands like `SOURCE` in MySQL and `\dt` in PostgreSQL won't work.
 
 `Alternate shell` runs the appropriate `mysql` or `psql` command to connect to your site's database. In this shell, commands like `SOURCE` in MySQL and `\dt` in PostgreSQL *will* work. However, for complicated technical reasons, this shell type takes much longer to load, so you may want to use `Database Shell` for quick operations.
+
+### What about Git?
+
+A previous version of Director allowed for the use of a webhook to automatically update from a Github repository. We have no plans to reintroduce this into Director as explained [here](../whatsnew-director4).
+
+If you require `git`, you can install it following the instructions [here](../best-practices/version-control).
+
+

--- a/whatsnew-director4.md
+++ b/whatsnew-director4.md
@@ -19,4 +19,5 @@ Title: What's new in Director 4.0
 ## Features that are no longer supported
 
 - Git integration has been removed because the new Director 4.0 architecture makes it more difficult to implement and we saw limited usage. Currently, there are no plans to add Git integration.
+  If you require Git, install it from the "Configure Docker Image" page by adding `git` to the list of packages at the bottom of the page.
 - The buttons for exporting/importing databases have been removed. You can still export/import databases, but you'll need to use `mysqldump`/`pg_dump` (exporting) and `mysql`/`psql` (importing) manually from the command line.


### PR DESCRIPTION
Add documentation regarding the removal of Github integration, and how to install `git` (and a `ssh` client).